### PR TITLE
Bump extension version to 0.1.6

### DIFF
--- a/Extension/extension-manifest.json
+++ b/Extension/extension-manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "urbancode-deploy-build-extension",
     "name": "IBM UrbanCode Deploy",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "publisher": "ms-vsts",
     "description": "Upload build artifacts to IBM UrbanCode Deploy",
     "public": true,


### PR DESCRIPTION
This is something that I should've added in #10 but missed. 

Without it, some of our account agents are still using the previous udclient task version (0.121.0) instead of the latest task version (0.122.0). Bumping the extension version should resolve this